### PR TITLE
#更新Dockerfle至2.2

### DIFF
--- a/src/Surging.ApiGateway/Dockerfile
+++ b/src/Surging.ApiGateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-runtime
+FROM microsoft/dotnet:2.2-runtime
 WORKDIR /app
 COPY . .
 ENTRYPOINT ["dotnet", "Surging.ApiGateway.dll"]


### PR DESCRIPTION
更新框架版本的时候Dockerfle没有对应拉去2.2的版本，导致很多人用默认的dockerfile打包好无法运行