### PR TITLE
修复地址模型如果设置的是域名则解析Endpoint失败的bug

### DIFF
--- a/src/Surging.Core/Surging.Core.CPlatform/Address/AddressHelper.cs
+++ b/src/Surging.Core/Surging.Core.CPlatform/Address/AddressHelper.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Surging.Core.CPlatform.Address
+{
+    public class AddressHelper
+    {
+        public static string GetIpFromAddress(string address)
+        {
+            if (IsValidIp(address))
+            {
+                return address;
+            }
+            var ips = Dns.GetHostAddresses(address);
+            return ips[0].ToString();
+        }
+
+        public static bool IsValidIp(string address)
+        {
+            if (Regex.IsMatch(address, "[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}"))
+            {
+                string[] ips = address.Split('.');
+                if (ips.Length == 4 || ips.Length == 6)
+                {
+                    if (int.Parse(ips[0]) < 256 && int.Parse(ips[1]) < 256 && int.Parse(ips[2]) < 256 && int.Parse(ips[3]) < 256)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Surging.Core/Surging.Core.CPlatform/Address/IpAddressModel.cs
+++ b/src/Surging.Core/Surging.Core.CPlatform/Address/IpAddressModel.cs
@@ -66,13 +66,13 @@ namespace Surging.Core.CPlatform.Address
         /// <returns></returns>
         public override EndPoint CreateEndPoint()
         {
-            return new IPEndPoint(IPAddress.Parse(Ip), Port);
+            return new IPEndPoint(IPAddress.Parse(AddressHelper.GetIpFromAddress(Ip)), Port);
         }
 
 
         public override string ToString()
         {
-            return string.Concat(new string[] {Ip,":" , Port.ToString() });
+            return string.Concat(new string[] { AddressHelper.GetIpFromAddress(Ip), ":" , Port.ToString() });
         }
 
         #endregion Overrides of AddressModel


### PR DESCRIPTION
如果使用`docker-compose`编排服务时,使用`consul:8500`作为服务注册中心地址,先把域名解析为IP的话,则无法创建端点