### PR TITLE
增加Docker部署模式

### DIFF
--- a/src/Surging.Core/Surging.Core.CPlatform/Configurations/DockerDeployMode.cs
+++ b/src/Surging.Core/Surging.Core.CPlatform/Configurations/DockerDeployMode.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Surging.Core.CPlatform.Configurations
+{
+    /// <summary>
+    /// Docker容器部署模式
+    /// </summary>
+    public enum DockerDeployMode
+    {
+        /// <summary>
+        /// 正常模式
+        /// </summary>
+        Standard,
+
+        /// <summary>
+        /// Swarm集群模式
+        /// </summary>
+        Swarm
+    }
+}

--- a/src/Surging.Core/Surging.Core.CPlatform/Configurations/SurgingServerOptions.cs
+++ b/src/Surging.Core/Surging.Core.CPlatform/Configurations/SurgingServerOptions.cs
@@ -23,6 +23,8 @@ namespace Surging.Core.CPlatform.Configurations
 
         public bool Libuv { get; set; } = false;
 
+        public DockerDeployMode DockerDeployMode { get; set; } = DockerDeployMode.Standard;
+
         public int SoBacklog { get; set; } = 8192;
 
         public bool EnableRouteWatch { get; set; }

--- a/src/Surging.Core/Surging.Core.KestrelHttpServer/KestrelHttpMessageListener.cs
+++ b/src/Surging.Core/Surging.Core.KestrelHttpServer/KestrelHttpMessageListener.cs
@@ -24,7 +24,9 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Surging.Core.KestrelHttpServer.Filters;
 using Surging.Core.CPlatform.Messages;
 using System.Diagnostics;
+using Surging.Core.CPlatform.Configurations;
 using Surging.Core.CPlatform.Diagnostics;
+using Surging.Core.CPlatform.Utilities;
 
 namespace Surging.Core.KestrelHttpServer
 {
@@ -58,6 +60,11 @@ namespace Surging.Core.KestrelHttpServer
         { 
             try
             {
+                if (AppConfig.ServerOptions.DockerDeployMode == DockerDeployMode.Swarm)
+                {
+                    address = IPAddress.Any;
+                }
+
                 var hostBuilder = new WebHostBuilder()
                   .UseContentRoot(Directory.GetCurrentDirectory())
                   .UseKestrel((context,options) =>

--- a/src/Surging.Services/Surging.Services.Server/surgingSettings.json
+++ b/src/Surging.Services/Surging.Services.Server/surgingSettings.json
@@ -7,6 +7,7 @@
     "MappingPort": "${Mapping_Port}",
     "Token": "true",
     "WanIp": "${WanIp}|192.168.249.103",
+    "DockerDeployMode": "${DockerDeployMode}|Standard",
     "Libuv": true,
     "SoBacklog": 100,
     "MaxConcurrentRequests": 20,


### PR DESCRIPTION
服务通过docker集群模式部署时，因有bridge、ingress不同网络，
kestrelserver通过NetUtils随机获取网络时，当只监听ingress网络，此时无法通过bridge访问swagger文档。
增加DockerDeployMode，配置为Swarm模式时，监听0.0.0.0地址。